### PR TITLE
Add built in close notification feature with TTC hardware warning for security+v2.0 doors

### DIFF
--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -25,6 +25,9 @@
 namespace esphome {
 namespace secplus_gdo {
 
+// Forward declaration
+class GDOComponent;
+
 using namespace esphome::cover;
 class GDODoor : public cover::Cover, public Component {
 public:
@@ -50,7 +53,9 @@ public:
     this->pre_close_duration_ = ms;
   }
   void set_toggle_only(bool val) { this->toggle_only_ = val; }
+  void set_close_notification(bool val) { this->close_notification_ = val; }
   void set_state(gdo_door_state_t state, float position);
+  void set_parent(class GDOComponent *parent) { this->parent_ = parent; }
 
 protected:
   void control(const cover::CoverCall &call);
@@ -59,10 +64,12 @@ protected:
   uint32_t pre_close_duration_{0};
   bool pre_close_active_{false};
   bool toggle_only_{false};
+  bool close_notification_{false};
   optional<float> target_position_{0};
   CoverOperation prev_operation{COVER_OPERATION_IDLE};
   gdo_door_state_t state_{GDO_DOOR_STATE_MAX};
   bool synced_{false};
+  class GDOComponent *parent_{nullptr};
 };
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -360,6 +360,14 @@ namespace esphome
           std::bind(&esphome::secplus_gdo::GDODoor::set_toggle_only, this->door_,
                     std::placeholders::_1));
 #endif
+#ifdef GDO_CLOSE_NOTIFY
+      // Set the close notification state and control here because we cannot guarantee the
+      // cover instance was created before the switch
+      this->door_->set_close_notification(this->close_notification_switch_->state);
+      this->close_notification_switch_->set_control_function(
+          std::bind(&esphome::secplus_gdo::GDODoor::set_close_notification, this->door_,
+                    std::placeholders::_1));
+#endif
 #ifdef GDO_OBST_OVERRIDE
       // Set the obstruction override state and control
       this->obst_override_switch_->set_control_function(

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -140,7 +140,10 @@ public:
 #endif
 
 
-  void register_door(GDODoor *door) { this->door_ = door; }
+  void register_door(GDODoor *door) { 
+    this->door_ = door; 
+    door->set_parent(this);
+  }
   void set_door_state(gdo_door_state_t state, float position) {
     if (this->door_) {
       this->door_->set_state(state, position);
@@ -220,9 +223,16 @@ public:
       time_to_close_->update_state(num);
     }
   }
+  uint16_t get_time_to_close() {
+    if (time_to_close_) {
+      return static_cast<uint16_t>(time_to_close_->state);
+    }
+    return 0;
+  }
 
   void register_toggle_only(GDOSwitch *sw) { this->toggle_only_switch_ = sw; }
   void register_obst_override(GDOSwitch *sw) { this->obst_override_switch_ = sw; }
+  void register_close_notification(GDOSwitch *sw) { this->close_notification_switch_ = sw; }
   void set_sync_state(bool synced);
 
   // Public method to defer operations to avoid blocking in event handlers
@@ -303,6 +313,7 @@ protected:
   GDOSwitch *learn_switch_{nullptr};
   GDOSwitch *toggle_only_switch_{nullptr};
   GDOSwitch *obst_override_switch_{nullptr};
+  GDOSwitch *close_notification_switch_{nullptr};
   bool start_gdo_{false};
   bool gdo_started_{false};
 

--- a/components/secplus_gdo/switch/__init__.py
+++ b/components/secplus_gdo/switch/__init__.py
@@ -14,6 +14,7 @@ TYPES = {
     "learn": "register_learn",
     "toggle_only": "register_toggle_only",
     "obst_override": "register_obst_override",
+    "close_notification": "register_close_notification",
 }
 
 
@@ -35,6 +36,9 @@ async def to_code(config):
         await switch.register_switch(var, config)
     elif "toggle_only" in str(config[CONF_TYPE]):
         cg.add_define("GDO_TOGGLE_ONLY")
+        await switch.register_switch(var, config)
+    elif "close_notification" in str(config[CONF_TYPE]):
+        cg.add_define("GDO_CLOSE_NOTIFY")
         await switch.register_switch(var, config)
     elif "obst_override" in str(config[CONF_TYPE]):
         cg.add_define("GDO_OBST_OVERRIDE")

--- a/components/secplus_gdo/switch/gdo_switch.h
+++ b/components/secplus_gdo/switch/gdo_switch.h
@@ -20,6 +20,7 @@ enum SwitchType {
   LEARN,
   TOGGLE_ONLY,
   OBST_OVERRIDE,
+  CLOSE_NOTIFICATION,
 };
 
 class GDOSwitch : public switch_::Switch, public Component {
@@ -49,6 +50,13 @@ public:
     }
 
     if (this->type_ == SwitchType::OBST_OVERRIDE) {
+      if (this->f_control) {
+        this->f_control(state);
+        this->pref_.save(&state);
+      }
+    }
+
+    if (this->type_ == SwitchType::CLOSE_NOTIFICATION) {
       if (this->f_control) {
         this->f_control(state);
         this->pref_.save(&state);


### PR DESCRIPTION
- Implement close notification switch with TTC (Time To Close) hardware command
- Add conditional branching for close operations (toggle, explicit close, position-based)
- Use TTC=1 second to trigger 10-second GDO warning then auto-close
- Restore original TTC value after warning completes
- Add parent pointer to GDODoor for accessing time_to_close entity
- Add forward declarations and includes for proper compilation